### PR TITLE
Validate active module documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # terraform-azure-modules
-This is a repo with custom Terraform modules for Azure cloud provider
+
+This repository contains custom Terraform modules for the Azure cloud provider.
+
+## Active modules
+
+| Module | Description |
+| --- | --- |
+| [`modules/data-factory`](modules/data-factory/README.md) | Deploys Azure Data Factory with managed virtual network integration runtimes, managed private endpoints, and PostgreSQL/ADLS Gen2 linked services. |
+
+Legacy modules are kept under [`legacy-modules`](legacy-modules/) for existing consumers.
+
+## Documentation validation
+
+Run the module documentation validation script before opening a pull request:
+
+```bash
+./scripts/validate-module-docs.py
+```
+
+The validation checks that each active module under `modules/` has a README file and that every Terraform `variable` and `output` block includes a `description` attribute.

--- a/modules/data-factory/README.md
+++ b/modules/data-factory/README.md
@@ -1,0 +1,104 @@
+# Azure Data Factory module
+
+This module deploys an Azure Data Factory instance with a user-assigned managed identity, managed virtual network integration runtimes, managed private endpoints, and linked services for PostgreSQL and Azure Data Lake Storage Gen2.
+
+## Resources created
+
+| Resource | Purpose |
+| --- | --- |
+| `azurerm_data_factory.factory` | Azure Data Factory instance with a user-assigned managed identity. |
+| `azurerm_data_factory_integration_runtime_azure.managed_vnet_ir` | Default managed virtual network Azure integration runtime. |
+| `azurerm_data_factory_integration_runtime_azure.large_managed_vnet_ir` | Memory-optimized managed virtual network Azure integration runtime. |
+| `azurerm_data_factory_managed_private_endpoint.postgres_via_pls` | Managed private endpoint to PostgreSQL through a Private Link Service. |
+| `azurerm_data_factory_managed_private_endpoint.storage_within_current_sub_via_pe` | Managed private endpoints to Storage accounts in the current subscription. |
+| `azurerm_data_factory_managed_private_endpoint.storage_out_current_sub_via_pe` | Managed private endpoints to Storage accounts outside the current subscription. |
+| `null_resource.approve_postgres_managed_pe` | Azure CLI approval for the PostgreSQL managed private endpoint connection. |
+| `null_resource.approve_storage_within_sub_managed_pe` | Azure CLI approval for Storage managed private endpoint connections in the current subscription. |
+| `null_resource.approve_storage_out_sub_managed_pe` | Azure CLI approval for Storage managed private endpoint connections outside the current subscription. |
+| `azapi_resource.postgresql_linked_service` | Azure Data Factory linked service for PostgreSQL. |
+| `azurerm_data_factory_linked_service_data_lake_storage_gen2.storage_linked_service` | Azure Data Factory linked services for ADLS Gen2 Storage accounts. |
+
+## Requirements
+
+| Name | Version |
+| --- | --- |
+| Terraform | `>= 1.7.2` |
+| azapi | `~> 2.2` |
+
+> The module also uses AzureRM resources, the `null_resource` provider, and Azure CLI commands from local-exec provisioners. Configure those providers in the calling stack and ensure `az` is available in the execution environment.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| --- | --- | --- | --- | --- |
+| `name` | The Data Factory name. | `string` | n/a | yes |
+| `identity_id` | The user-assigned managed identity ID used by Azure Data Factory. | `string` | n/a | yes |
+| `location` | The Azure region where the resources will be deployed. | `string` | n/a | yes |
+| `resource_group_name` | The resource group name. | `string` | n/a | yes |
+| `enable_managed_virtual_network` | Indicates whether to enable the Managed Virtual Network for Azure Data Factory. | `bool` | `true` | no |
+| `postgres_db_name` | The name of the PostgreSQL database. | `string` | n/a | yes |
+| `postgres_admin` | The PostgreSQL admin username. | `string` | n/a | yes |
+| `postgres_admin_password` | The PostgreSQL admin password. | `string` | n/a | yes |
+| `private_link_service_id` | The ID of the Private Link Service. | `string` | n/a | yes |
+| `private_link_service_name` | The name of the Private Link Service. | `string` | n/a | yes |
+| `postgres_fqdns` | List of fully qualified domain names used by Data Factory to validate the Managed Private Endpoint connection to PostgreSQL. | `list(string)` | `[]` | no |
+| `storages_within_sub_managed_pe` | Storage account managed private endpoints to create and approve in the current subscription. | <pre>list(object({<br>  name                 = string<br>  storage_account_name = string<br>  target_resource_id   = string<br>}))</pre> | n/a | yes |
+| `storage_out_sub_managed_pe` | Storage account managed private endpoints to create and approve outside the current subscription. | <pre>list(object({<br>  name                 = string<br>  storage_account_name = string<br>  target_resource_id   = string<br>}))</pre> | `[]` | no |
+| `client_id` | The Client ID of the Azure Service Principal. | `string` | n/a | yes |
+| `client_secret` | The Client Secret of the Azure Service Principal. | `string` | n/a | yes |
+| `tenant_id` | The Tenant ID associated with the Azure Service Principal. | `string` | n/a | yes |
+| `subscription_id` | The Azure subscription ID. | `string` | n/a | yes |
+| `tags` | Map of tags to apply to the Data Factory resource. | `map(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `data_factory_id` | The ID of the Azure Data Factory. |
+| `data_factory_name` | The name of the Azure Data Factory. |
+
+## Example
+
+```hcl
+module "data_factory" {
+  source = "./modules/data-factory"
+
+  name                = "adf-example-dev"
+  location            = "eastus"
+  resource_group_name = "rg-example-dev"
+  identity_id         = azurerm_user_assigned_identity.data_factory.id
+
+  postgres_db_name          = "appdb"
+  postgres_admin            = var.postgres_admin
+  postgres_admin_password   = var.postgres_admin_password
+  private_link_service_id   = azurerm_private_link_service.postgres.id
+  private_link_service_name = azurerm_private_link_service.postgres.name
+  postgres_fqdns            = ["postgres.example.privatelink.postgres.database.azure.com"]
+
+  storages_within_sub_managed_pe = [
+    {
+      name                 = "adls-current"
+      storage_account_name = "stadfcurrentdev"
+      target_resource_id   = azurerm_storage_account.current.id
+    }
+  ]
+
+  storage_out_sub_managed_pe = []
+
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
+
+  tags = {
+    environment = "dev"
+    workload    = "data-platform"
+  }
+}
+```
+
+## Operational notes
+
+- `postgres_fqdns` must contain at least one FQDN because the PostgreSQL connection string uses the first list item.
+- The service principal must be allowed to approve Private Endpoint connections for the Private Link Service and Storage accounts.
+- `client_secret` and `postgres_admin_password` are sensitive values. Pass them through secure variables or a secret store in the calling stack.

--- a/modules/data-factory/variables.tf
+++ b/modules/data-factory/variables.tf
@@ -4,12 +4,12 @@ variable "name" {
 }
 
 variable "identity_id" {
-  description = "The idetity used for Data Factory."
+  description = "The user-assigned managed identity ID used by Azure Data Factory."
   type        = string
 }
 
 variable "location" {
-  description = "The region were the resource will be deployed."
+  description = "The Azure region where the resources will be deployed."
   type        = string
 }
 
@@ -51,12 +51,13 @@ variable "private_link_service_name" {
 }
 
 variable "postgres_fqdns" {
-  description = "List of fully qualified domain names used by Data Factory to validate the Managed Private Endpoint connection to PostgreS."
+  description = "List of fully qualified domain names used by Data Factory to validate the Managed Private Endpoint connection to PostgreSQL."
   type        = list(string)
   default     = []
 }
 
 variable "storages_within_sub_managed_pe" {
+  description = "Storage account managed private endpoints to create and approve in the current subscription."
   type = list(object({
     name                 = string
     storage_account_name = string
@@ -65,6 +66,7 @@ variable "storages_within_sub_managed_pe" {
 }
 
 variable "storage_out_sub_managed_pe" {
+  description = "Storage account managed private endpoints to create and approve outside the current subscription."
   type = list(object({
     name                 = string
     storage_account_name = string

--- a/scripts/validate-module-docs.py
+++ b/scripts/validate-module-docs.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Validate baseline documentation coverage for Terraform modules."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+BLOCK_START = re.compile(r'^\s*(variable|output)\s+"([^"]+)"\s*\{')
+DESCRIPTION = re.compile(r'^\s*description\s*=')
+README_NAMES = ("README.md", "readme.md")
+
+
+def iter_module_dirs(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted(path for path in root.iterdir() if path.is_dir() and any(path.glob("*.tf")))
+
+
+def iter_tf_blocks(path: Path) -> list[tuple[str, str, int, list[str]]]:
+    blocks: list[tuple[str, str, int, list[str]]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    index = 0
+    while index < len(lines):
+        match = BLOCK_START.match(lines[index])
+        if not match:
+            index += 1
+            continue
+
+        kind, name = match.groups()
+        start_line = index + 1
+        depth = lines[index].count("{") - lines[index].count("}")
+        block_lines = [lines[index]]
+        index += 1
+
+        while index < len(lines) and depth > 0:
+            block_lines.append(lines[index])
+            depth += lines[index].count("{") - lines[index].count("}")
+            index += 1
+
+        blocks.append((kind, name, start_line, block_lines))
+
+    return blocks
+
+
+def validate_module(module_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if not any((module_dir / name).is_file() for name in README_NAMES):
+        errors.append(f"{module_dir}: missing README.md")
+
+    for tf_file in sorted(module_dir.glob("*.tf")):
+        for kind, name, line, block_lines in iter_tf_blocks(tf_file):
+            if not any(DESCRIPTION.match(block_line) for block_line in block_lines):
+                errors.append(
+                    f"{tf_file}:{line}: {kind} \"{name}\" is missing a description"
+                )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate that Terraform modules include a README and descriptions for variables/outputs."
+    )
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        default=["modules"],
+        help="Module root directories to validate (default: modules).",
+    )
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    module_count = 0
+    for root in args.roots:
+        module_dirs = iter_module_dirs(Path(root))
+        module_count += len(module_dirs)
+        for module_dir in module_dirs:
+            errors.extend(validate_module(module_dir))
+
+    if errors:
+        print("Module documentation validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Module documentation validation passed for {module_count} module(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Ensure each module under `modules/` has a README and every Terraform `variable`/`output` block includes a `description` to improve documentation quality and onboarding. 
- Provide an automated, reusable check to prevent regressions in module documentation coverage. 
- Fix typos and missing descriptions in the Data Factory module to make its public contract explicit.

### Description

- Add a validation script at `scripts/validate-module-docs.py` that checks each module in `modules/` for a README and `description` attributes on `variable`/`output` blocks. 
- Add a module README at `modules/data-factory/README.md` documenting resources, requirements, inputs, outputs, example usage, and operational notes. 
- Update the repository `README.md` to list active modules and document the documentation validation workflow. 
- Fill missing/incorrect descriptions and fix typos in `modules/data-factory/variables.tf` to provide clear variable documentation.

### Testing

- Ran `./scripts/validate-module-docs.py`, which reported success: "Module documentation validation passed for 1 module(s).". 
- Ran `python -m py_compile scripts/validate-module-docs.py`, which succeeded with no syntax errors. 
- Ran `git diff --check`, which returned no whitespace or diff problems. 
- `terraform fmt -check -recursive` was not executed because `terraform` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4ec37600832f8676d7059b418a13)